### PR TITLE
Add variant ways to launch app remotely and fix permission issue.

### DIFF
--- a/apps/system/js/app_window_factory.js
+++ b/apps/system/js/app_window_factory.js
@@ -44,6 +44,7 @@
         return;
       }
       this._started = true;
+      this.bc = new BroadcastChannel('multiscreen');
 
       window.addEventListener('webapps-launch', this.preHandleEvent);
       window.addEventListener('webapps-close', this.preHandleEvent);
@@ -166,6 +167,19 @@
      * @memberof AppWindowFactory.prototype
      */
     launch: function awf_launch(config) {
+      dump('AppWindowFactory::launch: ' + config.remoteId);
+
+      if (config.remoteId) {
+        dump('AppWindowFactory: ' + config.url + ', ' + config.manifestURL);
+
+        this.bc.postMessage({
+          url: config.url,
+          manifestURL: config.manifestURL
+        });
+
+        return;
+      }
+
       if (config.url === window.location.href) {
         return;
       }

--- a/apps/system/js/browser_config_helper.js
+++ b/apps/system/js/browser_config_helper.js
@@ -43,6 +43,7 @@
     var app = config.manifestURL &&
               applications.getByManifestURL(config.manifestURL);
     this.url = config.url;
+    this.remoteId = config.remoteId;
 
     if (app) {
       var manifest = app.manifest;

--- a/apps/system/js/browser_context_menu.js
+++ b/apps/system/js/browser_context_menu.js
@@ -24,6 +24,7 @@
     this.instanceID = _id++;
     this._injected = false;
     this.app.element.addEventListener('mozbrowsercontextmenu', this);
+    this.bc = new BroadcastChannel('multiscreen');
     return this;
   };
 
@@ -264,6 +265,13 @@
     newTabApp.launch();
   };
 
+  BrowserContextMenu.prototype.newRemoteWindow = function(url) {
+    this.bc.postMessage({
+      url: url,
+      manifestURL: null
+    });
+  };
+
   BrowserContextMenu.prototype.showWindows = function(manifest) {
     window.dispatchEvent(
       new CustomEvent('taskmanagershow',
@@ -335,6 +343,12 @@
     return new Promise((resolve) => {
       var config = this.app.config;
       var menuData = [];
+
+      menuData.push({
+        id: 'new-remote-window',
+        label: 'New remote window',
+        callback: this.newRemoteWindow.bind(this, config.url)
+      });
 
       menuData.push({
         id: 'new-window',

--- a/shared/elements/gaia_grid/js/grid_view.js
+++ b/shared/elements/gaia_grid/js/grid_view.js
@@ -246,6 +246,7 @@
       var inEditMode = this.dragdrop && this.dragdrop.inEditMode;
 
       var action = 'launch';
+      var remoteId = 0;
       if (e.target.classList.contains('remove')) {
         action = 'remove';
       }
@@ -259,9 +260,10 @@
         if (inEditMode && e.target.classList.contains('icon')) {
           // Check if we're trying to edit a bookmark or collection
           if (!icon.isEditable()) {
-            return;
+            remoteId = 1;
+          } else {
+            action = 'edit';
           }
-          action = 'edit';
         } else {
           // If the icon can't be launched, bail out early
           if (!icon[action]) {
@@ -302,7 +304,7 @@
         }.bind(this), APP_LAUNCH_TIMEOUT);
       }
 
-      icon[action](e.target);
+      icon[action](e.target, remoteId);
     },
 
     /**

--- a/shared/elements/gaia_grid/js/items/mozapp.js
+++ b/shared/elements/gaia_grid/js/items/mozapp.js
@@ -292,7 +292,7 @@
     /**
      * Resolves click action.
      */
-    launch: function() {
+    launch: function(target, remoteId) {
       var app = this.app;
 
       switch (this._determineState(app)) {
@@ -309,12 +309,15 @@
         window.performance.mark('appLaunch@' + app.manifest.name);
       }
 
+      var launchRemote = app.launchRemote ? app.launchRemote.bind(app, remoteId)
+                                          : app.launch.bind(app);
+
       if (this.entryPoint) {
-        return app.launch(this.entryPoint);
+        return launchRemote(this.entryPoint);
       }
 
       // Default action is to launch the app.
-      return app.launch();
+      return launchRemote();
     }
   };
 


### PR DESCRIPTION
- New ways to open an app in the remote window:
  1) Tap icons in edit mode at homescreen.
  2) Click 'New remote window' in the browser context menu.
- When open a new app in the remote window, kill the previous one to
  force to reload the manifest.
- Open remote app in the child process.
